### PR TITLE
Switch to rund, saves almost a second on first invocation of build.d

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1,4 +1,6 @@
-#!/usr/bin/env rdmd
+#!/usr/bin/env rund
+//!debug
+//!debugSymbols
 /**
 DMD builder
 


### PR DESCRIPTION
```
$ rm -rf /tmp/.rdmd-*/
$ time rdmd --build-only ./src/build.d

real	0m3.245s
user	0m2.763s
sys	0m0.487s
$ rm -rf /tmp/.rund-*/
$ time rund --build-only ./src/build.d

real	0m2.416s
user	0m2.070s
sys	0m0.346s
```